### PR TITLE
Update OTBR Thread version to 1.4

### DIFF
--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -87,7 +87,7 @@ RUN \
         -DOT_COAP=OFF \
         -DOT_COAPS=OFF \
         -DOT_DNS_CLIENT_OVER_TCP=OFF \
-        -DOT_THREAD_VERSION=1.3 \
+        -DOT_THREAD_VERSION=1.4 \
         -DOT_PROJECT_CONFIG="../openthread-core-ha-config-posix.h" \
         -DOT_RCP_RESTORATION_MAX_COUNT=2 \
         && cd build/otbr/ \


### PR DESCRIPTION
## Summary
- use Thread specification version 1.4 when building OpenThread Border Router

## Testing
- `grep -n DOT_THREAD_VERSION openthread_border_router/Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_685ab0297ad08322987c0ef8fb0d3c28