### PR TITLE
Update OTBR Thread version to 1.4

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.14.0
+- Bump to OTBR POSIX version 2a0ea49d (2025-06-23 17:17:09 +0000)
+- Bump universal-silabs-flasher to 0.0.31
+
 ## 2.13.0
 - Bump to OTBR POSIX version b067e5ac (2025-01-13 22:32:22 -0500)
 - Bump universal-silabs-flasher to 0.0.28

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -87,7 +87,7 @@ RUN \
         -DOT_COAP=OFF \
         -DOT_COAPS=OFF \
         -DOT_DNS_CLIENT_OVER_TCP=OFF \
-        -DOT_THREAD_VERSION=1.3 \
+        -DOT_THREAD_VERSION=1.4 \
         -DOT_PROJECT_CONFIG="../openthread-core-ha-config-posix.h" \
         -DOT_RCP_RESTORATION_MAX_COUNT=2 \
         && cd build/otbr/ \

--- a/openthread_border_router/build.yaml
+++ b/openthread_border_router/build.yaml
@@ -3,5 +3,5 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
 args:
-  OTBR_VERSION: b067e5ac5f8b3e92750df24922017eee2bc0fa04
-  UNIVERSAL_SILABS_FLASHER: 0.0.28
+  OTBR_VERSION: 2a0ea49d03e2b5289b639c53f7497bfdad098289
+  UNIVERSAL_SILABS_FLASHER: 0.0.31

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.13.0
+version: 2.14.0
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on


### PR DESCRIPTION
## Summary
- build OpenThread Border Router against Thread spec version 1.4
- bump OTBR POSIX and firmware flasher to latest commits
- release 2.14.0

## Testing
- `grep -n DOT_THREAD_VERSION openthread_border_router/Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_685ab0297ad08322987c0ef8fb0d3c28